### PR TITLE
updating dockerfile to node:20-alpine3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.15 as build
+FROM node:20-alpine3.17 as build
 USER node
 WORKDIR /home/node
 ADD --chown=node:node package*.json ./
@@ -6,7 +6,7 @@ RUN npm install
 ADD --chown=node:node . .
 RUN npm run build
 
-FROM node:16-alpine3.15 as solidity-build
+FROM node:20-alpine3.17 as solidity-build
 RUN apk add python3 alpine-sdk
 USER node
 WORKDIR /home/node
@@ -15,7 +15,7 @@ RUN npm install
 ADD --chown=node:node ./samples/solidity .
 RUN npx hardhat compile
 
-FROM node:16-alpine3.15
+FROM node:20-alpine3.17
 RUN apk add curl jq
 RUN mkdir -p /app/contracts/source \
     && chgrp -R 0 /app/ \


### PR DESCRIPTION
updating base image to fix CVEs.

Trivy scan results before this update:

```bash
$ trivy image --scanners vuln node:16-alpine3.15  --severity UNKNOWN,HIGH,CRITICAL --exit-code 1

2024-04-18T10:17:26.503-0400	INFO	Vulnerability scanning is enabled
2024-04-18T10:17:27.120-0400	INFO	Detected OS: alpine
2024-04-18T10:17:27.120-0400	INFO	Detecting Alpine vulnerabilities...
2024-04-18T10:17:27.122-0400	INFO	Number of language-specific files: 1
2024-04-18T10:17:27.122-0400	INFO	Detecting node-pkg vulnerabilities...
2024-04-18T10:17:27.128-0400	WARN	This OS version is no longer supported by the distribution: alpine 3.15.6
2024-04-18T10:17:27.128-0400	WARN	The vulnerability detection may be insufficient because security updates are not provided

node:16-alpine3.15 (alpine 3.15.6)

Total: 8 (UNKNOWN: 0, HIGH: 8, CRITICAL: 0)

┌──────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│   Library    │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                            │
├──────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ libcrypto1.1 │ CVE-2022-4450 │ HIGH     │ fixed  │ 1.1.1q-r0         │ 1.1.1t-r0     │ openssl: double free after calling PEM_read_bio_ex         │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                  │
│              ├───────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215 │          │        │                   │               │ openssl: use-after-free following BIO_new_NDEF             │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                  │
│              ├───────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0286 │          │        │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                  │
│              ├───────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0464 │          │        │                   │ 1.1.1t-r2     │ openssl: Denial of service by excessive resource usage in  │
│              │               │          │        │                   │               │ verifying X509 policy...                                   │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                  │
├──────────────┼───────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│ libssl1.1    │ CVE-2022-4450 │          │        │                   │ 1.1.1t-r0     │ openssl: double free after calling PEM_read_bio_ex         │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                  │
│              ├───────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0215 │          │        │                   │               │ openssl: use-after-free following BIO_new_NDEF             │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                  │
│              ├───────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0286 │          │        │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                  │
│              ├───────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│              │ CVE-2023-0464 │          │        │                   │ 1.1.1t-r2     │ openssl: Denial of service by excessive resource usage in  │
│              │               │          │        │                   │               │ verifying X509 policy...                                   │
│              │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                  │
└──────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
2024-04-18T10:17:27.133-0400	INFO	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Node.js (node-pkg)

Total: 1 (UNKNOWN: 0, HIGH: 1, CRITICAL: 0)

┌─────────────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│               Library               │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                            │
├─────────────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ http-cache-semantics (package.json) │ CVE-2022-25881 │ HIGH     │ fixed  │ 4.1.0             │ 4.1.1         │ http-cache-semantics: Regular Expression Denial of Service │
│                                     │                │          │        │                   │               │ (ReDoS) vulnerability                                      │
│                                     │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-25881                 │
└─────────────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```