### PR TITLE
CVE fix for axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@nestjs/swagger": "^11.0.0",
         "@nestjs/terminus": "^11.0.0",
         "@nestjs/websockets": "^11.0.0",
-        "axios": "^1.8.2",
+        "axios": "^1.13.5",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "lru-cache": "^7.10.1",
@@ -3832,13 +3832,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -6167,9 +6167,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nestjs/swagger": "^11.0.0",
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/websockets": "^11.0.0",
-    "axios": "^1.8.2",
+    "axios": "^1.13.5",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "lru-cache": "^7.10.1",


### PR DESCRIPTION
Bump axios to 1.13.5 for CVE

<img width="638" height="100" alt="Screenshot 2026-02-10 at 9 52 53 AM" src="https://github.com/user-attachments/assets/5669993b-9c8d-41c1-b00c-1c3075b156e7" />
